### PR TITLE
Refactored StartAccountHandler to better manage Goroutines liveness

### DIFF
--- a/src/model/account.go
+++ b/src/model/account.go
@@ -7,6 +7,7 @@ const (
 )
 
 const (
+	StatusPending = "Pending"
 	StatusSynced  = "Synced"
 	StatusOutSync = "OutSync"
 	StatusError   = "Error"


### PR DESCRIPTION
Goroutines are now killed when Accounts are deleted only.
Inactive accounts will be kept alive so as to not create overlapping processes when enabled or disabled accounts.